### PR TITLE
Corrections pour les mails

### DIFF
--- a/lang/en/report_coursemanager.php
+++ b/lang/en/report_coursemanager.php
@@ -87,21 +87,21 @@ $string['button_save_questionbank'] = 'Sauvegarder la banque de questions';
 $string['button_save_course'] = 'Sauvegarder tout le cours';
 $string['mail_subject_delete'] = 'Cours supprimé - {$a->course}';
 $string['mail_message_delete_oneteacher'] = 'Bonjour,<br />
-Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle,
-ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
+Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle, '.
+'ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
 Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours.';
 $string['mail_message_delete_main_teacher'] = 'Bonjour,<br />
-Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle,
-ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
+Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle, '.
+'ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
 Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours.<br />
-NOTE : ce cours contenait {$a->count_teacher} autres utilisateurs inscrits comme Enseignants. Un message leur a également été adressé pour leur indiquer que vous
+NOTE : ce cours contenait {$a->count_teacher} autres utilisateurs inscrits comme Enseignants. Un message leur a également été adressé pour leur indiquer que vous '.
 êtes à l\'origine de cette suppression. Etant également enseignants, ces personnes pourront également restaurer ce cours ou y récupérer des ressources.';
 $string['mail_message_delete_other_teacher'] = 'Bonjour,<br />
-Le cours {$a->course}, dans lequel vous êtes inscrit⋅e comme enseignant⋅e, a été déplacé dans la catégorie Corbeille par {$a->deleter}, en attente 
-de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle, ce cours reste accessible, notamment si vous souhaitez y récupérer des 
-ressources.<br />
-Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours, sous réserve de prévenir les autres
-enseignants.<br />';
+Le cours {$a->course}, dans lequel vous êtes inscrit⋅e comme enseignant⋅e, a été déplacé dans la catégorie Corbeille par {$a->deleter}, en attente '.
+'de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle, ce cours reste accessible, notamment si vous souhaitez y récupérer des '.
+'ressources.<br />
+Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours, sous réserve de prévenir les autres '.
+'enseignants.<br />';
 $string['delete_already_moved'] = 'Ce cours est déjà déplacé dans la catégorie Corbeille.';
 
 // Page - restauration des cours. 

--- a/lang/en/report_coursemanager.php
+++ b/lang/en/report_coursemanager.php
@@ -95,7 +95,7 @@ Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente
 'ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
 Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours.<br />
 NOTE : ce cours contenait {$a->count_teacher} autres utilisateurs inscrits comme Enseignants. Un message leur a également été adressé pour leur indiquer que vous '.
-êtes à l\'origine de cette suppression. Etant également enseignants, ces personnes pourront également restaurer ce cours ou y récupérer des ressources.';
+'êtes à l\'origine de cette suppression. Etant également enseignants, ces personnes pourront également restaurer ce cours ou y récupérer des ressources.';
 $string['mail_message_delete_other_teacher'] = 'Bonjour,<br />
 Le cours {$a->course}, dans lequel vous êtes inscrit⋅e comme enseignant⋅e, a été déplacé dans la catégorie Corbeille par {$a->deleter}, en attente '.
 'de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle, ce cours reste accessible, notamment si vous souhaitez y récupérer des '.

--- a/lang/en/report_coursemanager.php
+++ b/lang/en/report_coursemanager.php
@@ -87,18 +87,18 @@ $string['button_save_questionbank'] = 'Sauvegarder la banque de questions';
 $string['button_save_course'] = 'Sauvegarder tout le cours';
 $string['mail_subject_delete'] = 'Cours supprimé - {$a->course}';
 $string['mail_message_delete_oneteacher'] = 'Bonjour,<br />
-le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\intervalle,
+Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle,
 ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
-Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours .';
+Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours.';
 $string['mail_message_delete_main_teacher'] = 'Bonjour,<br />
-le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\intervalle,
+Le cours {$a->course} a été déplacé dans la catégorie Corbeille, en attente de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle,
 ce cours reste accessible, notamment si vous souhaitez y récupérer des ressources.<br />
 Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours.<br />
 NOTE : ce cours contenait {$a->count_teacher} autres utilisateurs inscrits comme Enseignants. Un message leur a également été adressé pour leur indiquer que vous
 êtes à l\'origine de cette suppression. Etant également enseignants, ces personnes pourront également restaurer ce cours ou y récupérer des ressources.';
 $string['mail_message_delete_other_teacher'] = 'Bonjour,<br />
-le cours {$a->course}, dans lequel vous êtes inscrit.e comme enseignant.e, a été déplacé dans la catégorie Corbeille par {$a->deleter}, en attente 
-de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\intervalle, ce cours reste accessible, notamment si vous souhaitez y récupérer des 
+Le cours {$a->course}, dans lequel vous êtes inscrit⋅e comme enseignant⋅e, a été déplacé dans la catégorie Corbeille par {$a->deleter}, en attente 
+de sa suppression définitive qui interviendra {$a->delete_period}. Dans l\'intervalle, ce cours reste accessible, notamment si vous souhaitez y récupérer des 
 ressources.<br />
 Si vous souhaitez le conserver, vous pouvez le restaurer hors de la corbeille depuis l\'interface de gestion de vos cours, sous réserve de prévenir les autres
 enseignants.<br />';


### PR DESCRIPTION
Bonjour,

Quelques propositions de corrections pour les mails d'avertissement lors d'une suppression de cours (ajout de majuscules, suppression d'une espace inutile, points médians, ajout d'apostrophe manquante).

J'ai également mis des apostrophes en fin de ligne (et début de la suivante) car dans le mail reçu, les retours à la ligne étaient interprétés dans le mail et on avait donc des retours à la ligne au milieu de phrase. Mais je ne sais pas si c'est la meilleure façon de faire…