### PR TITLE
redirect($url) mal placé

### DIFF
--- a/delete_course.php
+++ b/delete_course.php
@@ -128,6 +128,7 @@ if (!$confirm) {
 	$eventparams = array('context' => $context, 'courseid' => $courseid);
 	$event = \report_coursemanager\event\course_trash_moved::create($eventparams);
 	$event->trigger();
+
+	$url = new moodle_url('view.php', array('done' => 'course_deleted'));
+        redirect($url);
 }
-$url = new moodle_url('view.php', array('done' => 'course_deleted'));
-redirect($url);


### PR DESCRIPTION
Bonjour,

Sur la page de suppression de cours, j'avais le message d'erreur

> Erreur de programmation détectée. Ceci doit être corrigé par un programmeur : You cannot redirect after the entire page has been generated
> Erreur de programmation détectée. Ceci doit être corrigé par un programmeur : Invalid state passed to moodle_page::set_state. We are in state 3 and state 3 was requested.

tout en bas de la page.

En déplaçant la fonction redirect($url) juste avant la dernière accolade, ça semble rectifier le problème.