### PR TITLE
Report mailing – Bad course links and error with firstname sender

### DIFF
--- a/classes/task/mailing_task.php
+++ b/classes/task/mailing_task.php
@@ -39,6 +39,7 @@ class mailing_task extends \core\task\scheduled_task {
 
             // Define $from for mailing.
             $from = new \stdClass;
+            $from->firstname = '';
             $from->lastname = $CFG->supportname;
             $from->email = $CFG->supportname;
             $from->maildisplay = false;

--- a/classes/task/mailing_task.php
+++ b/classes/task/mailing_task.php
@@ -112,11 +112,12 @@ class mailing_task extends \core\task\scheduled_task {
                         if (!empty($checkreport)) {
                             // Heavy report leads to the specific page about course files.
                             if ($report['report'] == 'heavy') {
-                                $reportresult .= '- <a href="'.$CFG->wwwroot.'/report/coursemanager/course_files.php
-                                ?courseid='.$listcourse->courseid.'">'.$listcourse->coursename.'</a><br />';
+                                $reportresult .= '- <a href="'.$CFG->wwwroot
+                                .'/report/coursemanager/course_files.php?courseid='
+                                .$listcourse->courseid.'">'.$listcourse->coursename.'</a><br />';
                             } else {
-                                $reportresult .= '- <a href="'.$CFG->wwwroot.'/course/view.php
-                                ?id='.$listcourse->courseid.'">'.$listcourse->coursename.'</a><br />';
+                                $reportresult .= '- <a href="'.$CFG->wwwroot.'/course/view.php?id='
+                                .$listcourse->courseid.'">'.$listcourse->coursename.'</a><br />';
                             }
                         }
                     }


### PR DESCRIPTION
Les liens dans les rapports envoyés par mail contenaient de nombreux espaces à cause d'un retour à la ligne.
De plus, le nom affiché de l'expéditeur contenait {$a->firstname}.