### PR TITLE
Id dynamique comme identifiant du module assign

### DIFF
--- a/classes/task/run_orphan_submissions_report_task.php
+++ b/classes/task/run_orphan_submissions_report_task.php
@@ -52,14 +52,15 @@ class run_orphan_submissions_report_task extends \core\task\scheduled_task {
             global $CFG, $DB, $USER;
             $table = 'report_coursemanager_orphans';
 
-            $listassigns = $DB->get_records('assign', [], 'id ASC', 'id, course');
+	    $listassigns = $DB->get_records('assign', [], 'id ASC', 'id, course');
+	    $assignmoduleid = $DB->get_record('modules', ['name'=> 'assign'], 'id');
             foreach ($listassigns as $assign) {
                 $sqlcontextid = 'SELECT id
                 FROM {course_modules}
-                WHERE module = 1
+                WHERE module = ?
                 AND instance = ?
                 ';
-                $dbresultcontextid = $DB->get_record_sql($sqlcontextid, [$assign->id]);
+                $dbresultcontextid = $DB->get_record_sql($sqlcontextid, [$assignmoduleid->id, $assign->id]);
                 $cm = get_coursemodule_from_id('assign', $dbresultcontextid->id);
                 $context = \context_module::instance($cm->id);
 


### PR DESCRIPTION
Bonjour,
Petit patch pour corriger l'id hard coded, réglé sur 1 dans la requête.
C'est l'id dans la table module dans les nouvelles installations de Moodle, mais dans les anciennes installation ce n'est pas le cas et ça empêche la tâche de recherche de questions orphelines de bien se déroulée.